### PR TITLE
Fix route table association for new route tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ vnet_subnet_range = {
   "backend-subnet" = {
     "ip_range"                        = "10.10.10.0/24"
     "attach_nsg"                      = true
+    "attach_route_table"              = false
     "service_endpoints"               = null
     "apply_service_endpoint_policies" = true
     "apply_service_link_policies"     = false
@@ -17,6 +18,7 @@ vnet_subnet_range = {
   "databricks-host-subnet" = {
     "ip_range"                        = "10.10.11.0/24"
     "attach_nsg"                      = true
+    "attach_route_table"              = false
     "service_endpoints"               = null
     "apply_service_endpoint_policies" = false
     "apply_service_link_policies"     = false
@@ -78,7 +80,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_dns_servers"></a> [dns\_servers](#input\_dns\_servers) | DNS servers to be configured for the virtual network (will be added along with the Azure Magic IP) | `list(string)` | n/a | yes |
 | <a name="input_management_ip_range"></a> [management\_ip\_range](#input\_management\_ip\_range) | The IP range of the IQ3 management virtual network | `string` | n/a | yes |
-| <a name="input_routetable_resource_id"></a> [routetable\_resource\_id](#input\_routetable\_resource\_id) | Resource Id of the route table to be attached to the subnets | `string` | `""` | no |
+| <a name="input_route_table_id"></a> [route\_table\_id](#input\_route\_table\_id) | Resource Id of the route table to be attached to the subnets | `string` | `null` | no |
 | <a name="input_rule_default_prefix"></a> [rule\_default\_prefix](#input\_rule\_default\_prefix) | The prefix to add to the NSG and ASG rules | `string` | `"iq3"` | no |
 | <a name="input_virtual_network_tags"></a> [virtual\_network\_tags](#input\_virtual\_network\_tags) | Tags to be applied to the virtual network | `map(any)` | `null` | no |
 | <a name="input_vnet_ip_range"></a> [vnet\_ip\_range](#input\_vnet\_ip\_range) | The IP range of the whole Virtual Network | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -333,10 +333,10 @@ resource "azurerm_subnet_network_security_group_association" "nsg_association" {
 
 resource "azurerm_subnet_route_table_association" "rt_association" {
   subnet_id      = azurerm_subnet.subnet[each.key].id
-  route_table_id = var.routetable_resource_id
+  route_table_id = var.route_table_id
   for_each = {
     for key, value in var.vnet_subnet_ranges :
     key => value
-    if var.routetable_resource_id != ""
+    if value.attach_route_table
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,9 +52,9 @@ variable "vnet_subnet_ranges" {
   description = "A map of subnet names and their ranges (key: Subnet Name, Value: Subnet Range). For examples reference the README"
 }
 
-variable "routetable_resource_id" {
+variable "route_table_id" {
   type        = string
-  default     = ""
+  default     = null
   description = "Resource Id of the route table to be attached to the subnets"
 }
 


### PR DESCRIPTION
When trying to add a route table to the vnet module like this when the route table doesn't exist yet:
```terraform

module "skaylink_vnet" {
  source  = "skaylink/skaylink-vnet/azurerm"
  version = "1.0.0"

  vnet_name              = var.vnet_name
  management_ip_range    = "[hidden]"
  vnet_ip_range          = var.vnet_ip_range
  vnet_resourcegroup     = data.azurerm_resource_group.vnet_resourcegroup.name
  vnet_subnet_ranges     = var.vnet_subnet_ranges
  routetable_resource_id = azurerm_route_table.default.id
}

resource "azurerm_route_table" "default" {
  name                = "[hidden]"
  resource_group_name = var.resource_group_name
  location            = data.azurerm_resource_group.vnet_resourcegroup.location
}
```

Terraform returns this error:
```
Error: Invalid for_each argument
│
│   on ..\..\..\terraform-azurerm-skaylink-vnet\main.tf line 337, in resource "azurerm_subnet_route_table_association" "rt_association":
│  337:   for_each = {
│  338:     for key, value in var.vnet_subnet_ranges :
│  339:     key => value
│  340:     if var.routetable_resource_id != ""
│  341:   }
│     ├────────────────
│     │ var.routetable_resource_id is a string, known only after apply
│     │ var.vnet_subnet_ranges is map of object with 3 elements
│
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the
│ instances of this resource.
│
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.
│
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```

Because the ID of the route table is not yet known since it hasn't been created yet.

This PR fixes this by using a new attribute in the subnet configuration called `attach_route_table`:
```terraform
vnet_subnet_ranges = {
  "s-weu-dev-dcpnet-snet-aks" = {
    ip_range                        = "10.181.96.0/21"
    attach_nsg                      = false
    attach_route_table              = true # <--- new property
    [...]
  }
}
```
This value is statically known and can be safely used in the `for_each`. Furthermore this allows for configuring some subnets to use the route table while not using it for others.

Lastly the variable for the route table has been renamed from `routetable_resource_id` to `route_table_id`.