### PR TITLE
Fix DNS resolving by removing fallback to Azure DNS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ resource "azurerm_virtual_network" "vnet" {
   address_space       = var.vnet_ip_range
   location            = data.azurerm_resource_group.vnet_rg.location
   resource_group_name = data.azurerm_resource_group.vnet_rg.name
-  dns_servers         = length(var.dns_servers) == 0 ? [] : concat(var.dns_servers, ["168.63.129.16"])
+  dns_servers         = var.dns_servers == null || length(var.dns_servers) == 0 ? [] : var.dns_servers
 
   tags = var.virtual_network_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,8 @@ variable "vnet_resourcegroup" {
 
 variable "dns_servers" {
   type        = list(string)
-  description = "DNS servers to be configured for the virtual network (will be added along with the Azure Magic IP)"
+  description = "DNS servers to be configured for the virtual network."
+  default     = null
 }
 
 variable "vnet_subnet_ranges" {


### PR DESCRIPTION
If a VM decided to use Azure DNS, then entries located in Private DNS Zones not explicitly linked with the VNET wouldn't resolve.