### PR TITLE
updated values that were going to be deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -312,8 +312,8 @@ resource "azurerm_subnet" "subnet" {
   virtual_network_name                          = azurerm_virtual_network.vnet.name
   address_prefixes                              = [each.value.ip_range]
   service_endpoints                             = try(each.value.service_endpoints, null) == null ? null : each.value.service_endpoints
-  private_endpoint_network_policies_enabled     = each.value.apply_service_endpoint_policies
-  private_link_service_network_policies_enabled = each.value.apply_service_link_policies
+  private_endpoint_network_policies_enabled     = each.value.private_endpoint_network_policies_enabled
+  private_link_service_network_policies_enabled = each.value.private_link_service_network_policies_enabled
 
   dynamic "delegation" {
     for_each = each.value.service_delegation[*]

--- a/main.tf
+++ b/main.tf
@@ -307,13 +307,13 @@ resource "azurerm_virtual_network_dns_servers" "dns" {
 }
 
 resource "azurerm_subnet" "subnet" {
-  name                                           = each.key
-  resource_group_name                            = data.azurerm_resource_group.vnet_rg.name
-  virtual_network_name                           = azurerm_virtual_network.vnet.name
-  address_prefixes                               = [each.value.ip_range]
-  service_endpoints                              = try(each.value.service_endpoints, null) == null ? null : each.value.service_endpoints
-  enforce_private_link_endpoint_network_policies = each.value.apply_service_endpoint_policies
-  enforce_private_link_service_network_policies  = each.value.apply_service_link_policies
+  name                                          = each.key
+  resource_group_name                           = data.azurerm_resource_group.vnet_rg.name
+  virtual_network_name                          = azurerm_virtual_network.vnet.name
+  address_prefixes                              = [each.value.ip_range]
+  service_endpoints                             = try(each.value.service_endpoints, null) == null ? null : each.value.service_endpoints
+  private_endpoint_network_policies_enabled     = each.value.apply_service_endpoint_policies
+  private_link_service_network_policies_enabled = each.value.apply_service_link_policies
 
   dynamic "delegation" {
     for_each = each.value.service_delegation[*]

--- a/variables.tf
+++ b/variables.tf
@@ -59,14 +59,15 @@ variable "vnet_subnet_ranges" {
   vnet_subnet_range = {
     # Subnet without service_delegation
     "backend-subnet" = {
-      "ip_range"                        = "10.10.10.0/24"
-      "attach_nsg"                      = true
-      "attach_route_table"              = false
-      "service_endpoints"               = []
-      "apply_service_endpoint_policies" = true
-      "apply_service_link_policies"     = false
-      "service_delegation"              = null
-      "service_delegation_actions"      = []
+      "ip_range"                                      = "10.10.10.0/24"
+      "private_link_service_network_policies_enabled" = true
+      "attach_nsg"                                    = true
+      "attach_route_table"                            = false
+      "service_endpoints"                             = []
+      "apply_service_endpoint_policies"               = true
+      "apply_service_link_policies"                   = false
+      "service_delegation"                            = null
+      "service_delegation_actions"                    = []
   }
   ```
   EOF

--- a/variables.tf
+++ b/variables.tf
@@ -63,8 +63,8 @@ variable "vnet_subnet_ranges" {
       "attach_nsg"                                    = true
       "attach_route_table"                            = false
       "service_endpoints"                             = []
-      "apply_service_endpoint_policies"               = true
-      "apply_service_link_policies"                   = true
+      "private_endpoint_network_policies_enabled"     = true
+      "private_link_service_network_policies_enabled" = true
       "service_delegation"                            = null
       "service_delegation_actions"                    = []
   }

--- a/variables.tf
+++ b/variables.tf
@@ -60,12 +60,11 @@ variable "vnet_subnet_ranges" {
     # Subnet without service_delegation
     "backend-subnet" = {
       "ip_range"                                      = "10.10.10.0/24"
-      "private_link_service_network_policies_enabled" = true
       "attach_nsg"                                    = true
       "attach_route_table"                            = false
       "service_endpoints"                             = []
       "apply_service_endpoint_policies"               = true
-      "apply_service_link_policies"                   = false
+      "apply_service_link_policies"                   = true
       "service_delegation"                            = null
       "service_delegation_actions"                    = []
   }


### PR DESCRIPTION
- Updated numerous deprecated values:
	- `enforce_private_link_endpoint_network_policies` -> `private_endpoint_network_policies_enabled`
	- `enforce_private_link_service_network_policies` -> `private_link_service_network_policies_enabled`

From the users PoV nothing has changed. If you want to update the `private_endpoint_network_policies_enabled` value, you need to set the `apply_service_endpoint_policies` key, and if you want to update `private_link_service_network_policies_enabled` you need to set the `apply_service_link_policies` key