### PR TITLE
Inserted a depends on in bastion host

### DIFF
--- a/bastion.tf
+++ b/bastion.tf
@@ -35,4 +35,8 @@ resource "azurerm_bastion_host" "bastion_host" {
     public_ip_address_id = azurerm_public_ip.bastion_ip[0].id
     subnet_id            = azurerm_subnet.bastion_snt[0].id
   }
+
+  depends_on = [
+    azurerm_subnet.bastion_snt
+  ]
 }


### PR DESCRIPTION
Happened upon this error when deploying a VNET with a bastion subnet: https://dev.azure.com/henkeldx/hmanagedcloud/_build/results?buildId=178404&view=logs&j=2dd96ba9-dcf7-5a6c-d5af-4658757025ae&t=55e573f4-3f1a-5620-b8cb-91c7ffb0abd1